### PR TITLE
fix: most key deletions are best-effort

### DIFF
--- a/pkg/secrets/aws_param_store.go
+++ b/pkg/secrets/aws_param_store.go
@@ -53,7 +53,7 @@ func newAWSProvider(ctx context.Context, cmd *cli.Command) (Manager, error) {
 	}
 
 	return &awsProvider{
-		keyID:  aws.String(cmd.String("secrets-aws-kms-key-id")),
+		keyID:  new(cmd.String("secrets-aws-kms-key-id")),
 		client: ssm.NewFromConfig(cfg),
 	}, nil
 }
@@ -62,19 +62,19 @@ func newAWSProvider(ctx context.Context, cmd *cli.Command) (Manager, error) {
 // https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html.
 func (p *awsProvider) Set(ctx context.Context, key, value string) error {
 	_, err := p.client.PutParameter(ctx, &ssm.PutParameterInput{
-		Name:      aws.String("/" + key),
-		Value:     aws.String(value),
+		Name:      new("/" + key),
+		Value:     new(value),
 		Type:      types.ParameterTypeSecureString,
 		KeyId:     p.keyID,
-		Overwrite: aws.Bool(true),
+		Overwrite: new(true),
 	})
 	return err
 }
 
 func (p *awsProvider) Get(ctx context.Context, key string) (string, error) {
 	out, err := p.client.GetParameter(ctx, &ssm.GetParameterInput{
-		Name:           aws.String("/" + key),
-		WithDecryption: aws.Bool(true),
+		Name:           new("/" + key),
+		WithDecryption: new(true),
 	})
 	if err != nil {
 		var pnf *types.ParameterNotFound
@@ -88,6 +88,6 @@ func (p *awsProvider) Get(ctx context.Context, key string) (string, error) {
 }
 
 func (p *awsProvider) Delete(ctx context.Context, key string) error {
-	_, err := p.client.DeleteParameter(ctx, &ssm.DeleteParameterInput{Name: aws.String("/" + key)})
+	_, err := p.client.DeleteParameter(ctx, &ssm.DeleteParameterInput{Name: new("/" + key)})
 	return err
 }

--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -128,21 +128,24 @@ func (s *grpcServer) DeleteLink(ctx context.Context, in *thrippypb.DeleteLinkReq
 		return nil, status.Error(codes.NotFound, "link not found")
 	}
 
+	// All key deletions are best-effort (they may not exist), except for the link template.
+	var errs []string
 	if err := s.sm.Delete(ctx, id+"/creds"); err != nil {
-		l.Error("secrets manager delete error: creds", slog.Any("error", err))
-		return nil, status.Error(codes.Internal, "secrets manager delete error: creds")
+		l.Warn("secrets manager delete error", slog.Any("error", err), slog.String("suffix", "creds"))
+		errs = append(errs, "creds")
 	}
 	if err := s.sm.Delete(ctx, id+"/meta"); err != nil {
-		l.Error("secrets manager delete error: meta", slog.Any("error", err))
-		return nil, status.Error(codes.Internal, "secrets manager delete error: meta")
+		l.Warn("secrets manager delete error", slog.Any("error", err), slog.String("suffix", "meta"))
+		errs = append(errs, "meta")
 	}
 	if err := s.sm.Delete(ctx, id+"/oauth"); err != nil {
-		l.Error("secrets manager delete error: oauth", slog.Any("error", err))
-		return nil, status.Error(codes.Internal, "secrets manager delete error: oauth")
+		l.Warn("secrets manager delete error", slog.Any("error", err), slog.String("suffix", "oauth"))
+		errs = append(errs, "oauth")
 	}
 	if err := s.sm.Delete(ctx, id+"/template"); err != nil {
-		l.Error("secrets manager delete error: template", slog.Any("error", err))
-		return nil, status.Error(codes.Internal, "secrets manager delete error: template")
+		l.Error("secrets manager delete error", slog.Any("error", err), slog.String("suffix", "template"))
+		errs = append(errs, "template")
+		return nil, status.Error(codes.Internal, "secrets manager delete error: "+strings.Join(errs, ", "))
 	}
 
 	return &thrippypb.DeleteLinkResponse{}, nil


### PR DESCRIPTION
i.e. should be reported, but not cause an error (unless the mandatory key couldn't be deleted either)